### PR TITLE
Add support@datopian.com to the support mails

### DIFF
--- a/ckanext/rvr/templates/package/read.html
+++ b/ckanext/rvr/templates/package/read.html
@@ -3,7 +3,7 @@
 {% block primary_content_inner %}
 {{ super() }}
 <section class="report-dataset">
-    <h3> <a href="mailto:opendata@rvr.ruhr,support@datopian.com?subject={{ _('Fehler im Datensatz melden') }} {{ h.url_for(controller='dataset', action='read', id=pkg.name, _external=True) }}">{{ _('Fehler im Datensatz melden') }}</a></h3>
+    <h3> <a href="mailto:opendata@rvr.ruhr,support@datopian.com?subject={{ _('Fehler im Datensatz melden') }} {{ h.url_for(controller='dataset', action='read', id=pkg.name, _external=True) }}" target="_blank" rel="noopener noreferrer">{{ _('Fehler im Datensatz melden') }}</a></h3>
 </section>
 
 {% endblock %}


### PR DESCRIPTION
This update would add support@datopian.com to the mailto link, and also open the mail in a new tab

The update has been deployed to the [dev site](https://ckan.rvr.dev.datopian.com), and you can use this dataset: https://ckan.rvr.dev.datopian.com/dataset/test-dataset to test the update.